### PR TITLE
added preference for Message model to fix undefined createAttachment …

### DIFF
--- a/src/Model/Email/Message.php
+++ b/src/Model/Email/Message.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace Fooman\EmailAttachments\Model\Email;
+
+use Zend\Mime\Mime;
+use Zend\Mime\Part;
+
+class Message extends \Magento\Framework\Mail\Message implements \Magento\Framework\Mail\MailMessageInterface {
+
+    /**
+     * @var [] \Fooman\EmailAttachments\Model\Api\AttachmentInterface
+     */
+    private $_attachments;
+
+    /**
+     * @var \Zend\Mail\Message
+     */
+    private $zendMessage;
+
+    /**
+     * Message type
+     *
+     * @var string
+     */
+    private $messageType = self::TYPE_TEXT;
+
+    /**
+     * Initialize dependencies.
+     *
+     * @param string $charset
+     */
+    public function __construct($charset = 'utf-8') {
+        $this->zendMessage = new \Zend\Mail\Message();
+        $this->zendMessage->setEncoding($charset);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated
+     * @see \Magento\Framework\Mail\Message::setBodyText
+     * @see \Magento\Framework\Mail\Message::setBodyHtml
+     */
+    public function setMessageType($type) {
+        $this->messageType = $type;
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated
+     * @see \Magento\Framework\Mail\Message::setBodyText
+     * @see \Magento\Framework\Mail\Message::setBodyHtml
+     * @see https://akrabat.com/sending-attachments-in-multipart-emails-with-zendmail/
+     */
+    public function setBody($bodyText) {
+        if (is_string($bodyText) && $this->messageType === Mime::TYPE_HTML) {
+            $part = $this->createHtmlMimePart($bodyText);
+        }
+        else {
+            $part = $this->createTextMimePart($bodyText);
+        }
+
+
+        $body = new \Zend\Mime\Message();
+        if (!empty($this->_attachments)) {
+//            $content = new \Zend\Mime\Message();
+//            $content->addPart($part);
+//
+//            $contentPart = new Part($content->generateMessage());
+//            $contentPart->type = Mime::MULTIPART_ALTERNATIVE . ";\n" . ' boundary="' . $content->getMime()->boundary() . '"';
+//            $body->addPart($contentPart);
+            $body->addPart($part);
+            $messageType = Mime::MULTIPART_RELATED;
+
+            foreach ($this->_attachments as $attachment) {
+                $attachmentPart = new Part($attachment->getContent());
+                $attachmentPart->filename = $this->_encodedFileName($attachment->getFilename());
+                $attachmentPart->type = $attachment->getMimeType();
+                $attachmentPart->encoding = $attachment->getEncoding();
+                $attachmentPart->disposition = $attachment->getDisposition();
+                $body->addPart($attachmentPart);
+            }
+        }
+        else {
+            $body->addPart($part);
+            $messageType = $this->messageType;
+        }
+
+        $this->zendMessage->setBody($body);
+        $this->zendMessage->getHeaders()->get('content-type')->setType($messageType);
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setSubject($subject) {
+        $this->zendMessage->setSubject($subject);
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSubject() {
+        return $this->zendMessage->getSubject();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBody() {
+        return $this->zendMessage->getBody();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setFrom($fromAddress) {
+        $this->zendMessage->setFrom($fromAddress);
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addTo($toAddress) {
+        $this->zendMessage->addTo($toAddress);
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addCc($ccAddress) {
+        $this->zendMessage->addCc($ccAddress);
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addBcc($bccAddress) {
+        $this->zendMessage->addBcc($bccAddress);
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setReplyTo($replyToAddress) {
+        $this->zendMessage->setReplyTo($replyToAddress);
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRawMessage() {
+        return $this->zendMessage->toString();
+    }
+
+    /**
+     * Create HTML mime message from the string.
+     *
+     * @param string $htmlBody
+     * @return \Zend\Mime\Message
+     */
+    private function createHtmlMimeFromString($htmlBody) {
+        $htmlPart = new Part($htmlBody);
+        $htmlPart->setCharset($this->zendMessage->getEncoding());
+        $htmlPart->setType(Mime::TYPE_HTML);
+        $mimeMessage = new \Zend\Mime\Message();
+        $mimeMessage->addPart($htmlPart);
+        return $mimeMessage;
+    }
+
+    /**
+     * Create HTML mime part from the string.
+     *
+     * @access private
+     * @param string $html
+     * @return \Zend\Mime\Part
+     */
+    private function createHtmlMimePart($html) {
+        $htmlPart = new Part($html);
+        $htmlPart->setCharset($this->zendMessage->getEncoding());
+        $htmlPart->setType(Mime::TYPE_HTML);        
+        $htmlPart->setEncoding(Mime::ENCODING_QUOTEDPRINTABLE);
+        return $htmlPart;
+    }
+
+    /**
+     * Create plain text mime part from the string.
+     *
+     * @access private
+     * @param string $text
+     * @return \Zend\Mime\Part
+     */
+    private function createTextMimePart($text) {
+        $textPart = new Part($text);
+        $textPart->setCharset($this->zendMessage->getEncoding());
+        $textPart->setType(Mime::TYPE_TEXT);
+        $textPart->setEncoding(Mime::ENCODING_QUOTEDPRINTABLE);
+        return $textPart;
+    }
+
+    private function _encodedFileName($subject) {
+        return sprintf('=?utf-8?B?%s?=', base64_encode($subject));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setBodyHtml($html) {
+        $this->setMessageType(self::TYPE_HTML);
+        return $this->setBody($html);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setBodyText($text) {
+        $this->setMessageType(self::TYPE_TEXT);
+        return $this->setBody($text);
+    }
+
+    /**
+     * Add attachment for this message
+     * 
+     * @access public
+     * @param \Fooman\EmailAttachments\Model\Api\AttachmentInterface $attachment
+     */
+    public function addAttachment($attachment) {
+        $this->_attachments[] = $attachment;
+    }
+
+}

--- a/src/Model/MailTransportBuilder.php
+++ b/src/Model/MailTransportBuilder.php
@@ -16,13 +16,17 @@ class MailTransportBuilder extends \Magento\Framework\Mail\Template\TransportBui
      */
     public function addAttachment(Api\AttachmentInterface $attachment)
     {
-        $this->message->createAttachment(
-            $attachment->getContent(),
-            $attachment->getMimeType(),
-            $attachment->getDisposition(),
-            $attachment->getEncoding(),
-            $this->encodedFileName($attachment->getFilename())
-        );
+        $this->message->addAttachment($attachment);
+        
+        //this doesn't work in 2.3 as \Magento\Framework\Mail\Message doesn't extend \Zend_Mail
+        //any more, so the createAttachment method is undefined -> fatal error
+//        $this->message->createAttachment(
+//            $attachment->getContent(),
+//            $attachment->getMimeType(),
+//            $attachment->getDisposition(),
+//            $attachment->getEncoding(),
+//            $this->encodedFileName($attachment->getFilename())
+//        );
     }
 
     protected function encodedFileName($subject)

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -36,6 +36,9 @@
                 type="Fooman\EmailAttachments\Model\Email\Sender\CreditmemoSender"/>
     <preference for="\Magento\Sales\Model\Order\Email\Sender\CreditmemoCommentSender"
                 type="Fooman\EmailAttachments\Model\Email\Sender\CreditmemoCommentSender"/>
+    
+    <preference for="Magento\Framework\Mail\MessageInterface"
+                type="Fooman\EmailAttachments\Model\Email\Message" />
 
     <!-- module introduced preferences -->
     <preference for="Fooman\EmailAttachments\Model\Api\AttachmentContainerInterface"


### PR DESCRIPTION
Our team is currently developing on magento 2.3-develop as this should be released soon and we have a big project that needed some features from that branch.

I realised when I installed Email attachments extension with composer that it always finishes with fatal error as \Magento\Framework\Mail\Message doesn't extend \Zend_Mail any more, so the createAttachment method is undefined.

I had to edit Message::setBody() method and extend it to be able to add attachments to mail body. I had to copy the whole class as the $zendMessage property is private and therefore I could not access it. It was the best solution that I came up with, please suggest if you think it could be done a better way. It's working fine so far and if you don't have any other suggestions it could be even included in the master branch. I think the preference will be compatible with current stable versions of magento 2.